### PR TITLE
riot/ble/ble_scan: use nrf52dk everywhere

### DIFF
--- a/riot/ble/ble_scan/Makefile
+++ b/riot/ble/ble_scan/Makefile
@@ -2,7 +2,7 @@
 APPLICATION = ble_scan_rss
 
 # If no BOARD is found in the environment, use this default:
-BOARD ?= dwm1001
+BOARD ?= nrf52dk
 
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../../RIOT

--- a/riot/ble/ble_scan/ble_scan.ipynb
+++ b/riot/ble/ble_scan/ble_scan.ipynb
@@ -13,7 +13,9 @@
     "For exercise, we prepared RIOT applications and Python scripts that will allow you to:\n",
     "- build an application with shell command to start a BLE scan and to send BLE advertise paquets\n",
     "- retrieve the scan output and store it in a file on this Juputerlab server\n",
-    "- plot several radio informations related to the caprtured BLE packets"
+    "- plot several radio informations related to the caprtured BLE packets\n",
+    "\n",
+    "_Note:_ if no nRF52DK are available you can also try with [DWM1001](https://www.iot-lab.info/docs/boards/decawave-dwm1001/) or [nRF52840DK](https://www.iot-lab.info/docs/boards/nordic-nrf52840dk/) ."
    ]
   },
   {
@@ -97,7 +99,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!iotlab-node --flash bin/dwm1001/ble_scan_rss.bin"
+    "!iotlab-node --flash bin/nrf52dk/ble_scan_rss.bin"
    ]
   },
   {
@@ -194,7 +196,7 @@
     " - scan_cycles: the number of scan cycles\n",
     "    \n",
     "> scan json 100 100\n",
-    "{\"nodes\": [{\"addr\":[\"CC\",\"3E\",\"19\",\"71\",\"63\",\"70\"],\"addr_type\":1,\"name\":\"dwm1001-2\",\"adv_type\":0,\"ad_data\":[\"02\",\"01\",\"06\",\"0A\",\"08\",\"64\",\"77\",\"6D\",\"31\",\"30\",\"30\",\"31\",\"2D\",\"32\",\"02\",\"0A\",\"00\"],\"last_rssi\":-53,\"txpwr_dbm\":0,\"adv_msg_cnt\":826,\"first_update\":1115111832,\"last_update\":1145030423}, {\"addr\":[\"DB\",\"DD\",\"06\",\"5A\",\"89\",\"E8\"],\"addr_type\":1,\"name\":\"dwm1001-3\",\"adv_type\":0,\"ad_data\":[\"02\",\"01\",\"06\",\"0A\",\"08\",\"64\",\"77\",\"6D\",\"31\",\"30\",\"30\",\"31\",\"2D\",\"33\",\"02\",\"0A\",\"00\"],\"last_rssi\":-64,\"txpwr_dbm\":0,\"adv_msg_cnt\":852,\"first_update\":1115096137,\"last_update\":1144961615}]}\n",
+    "{\"nodes\": [{\"addr\":[\"CC\",\"3E\",\"19\",\"71\",\"63\",\"70\"],\"addr_type\":1,\"name\":\"nrf52dk-2\",\"adv_type\":0,\"ad_data\":[\"02\",\"01\",\"06\",\"0A\",\"08\",\"64\",\"77\",\"6D\",\"31\",\"30\",\"30\",\"31\",\"2D\",\"32\",\"02\",\"0A\",\"00\"],\"last_rssi\":-53,\"txpwr_dbm\":0,\"adv_msg_cnt\":826,\"first_update\":1115111832,\"last_update\":1145030423}, {\"addr\":[\"DB\",\"DD\",\"06\",\"5A\",\"89\",\"E8\"],\"addr_type\":1,\"name\":\"dwm1001-3\",\"adv_type\":0,\"ad_data\":[\"02\",\"01\",\"06\",\"0A\",\"08\",\"64\",\"77\",\"6D\",\"31\",\"30\",\"30\",\"31\",\"2D\",\"33\",\"02\",\"0A\",\"00\"],\"last_rssi\":-64,\"txpwr_dbm\":0,\"adv_msg_cnt\":852,\"first_update\":1115096137,\"last_update\":1144961615}]}\n",
     "..."
    ]
   },


### PR DESCRIPTION
There was some places in code where nrf52dk was used and others dwm1001, this PR uses dwm1001 for all (less used and less BLE interference)